### PR TITLE
Fix integration between contact edit, contact delete and meetings

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -2,12 +2,15 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 
@@ -40,10 +43,33 @@ public class DeleteCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED);
         }
 
+        // Update address book
         List<Person> filteredList = model.getFilteredPersonList().stream()
                 .filter(person -> person.isSameName(targetName)).collect(Collectors.toList());
         Person personToDelete = filteredList.get(0);
         model.deletePerson(personToDelete);
+
+        // Update meeting book
+        List<Meeting> filteredMeetingList = model.getFilteredMeetingList().stream()
+                .filter(meeting -> meeting.getMembers().contains(personToDelete)).map(meeting -> {
+                    Set<Person> updatedMembers = new HashSet<>(meeting.getMembers());
+                    updatedMembers.remove(personToDelete);
+                    Meeting updatedMeeting = new Meeting(meeting.getMeetingName(), meeting.getDate(),
+                            meeting.getTime(), updatedMembers);
+                    model.setMeeting(meeting, updatedMeeting);
+                    return updatedMeeting;
+                }).collect(Collectors.toList());
+
+        // todo update module book
+        //        List<Meeting> filteredModuleList = model.getFilteredModuleList().stream()
+        //                .filter(module -> module.getClassmates().contains(personToDelete)).map(module -> {
+        //                    Set<Person> updatedClassmates = new HashSet<>(module.getClassmates());
+        //                    updatedClassmates.remove(personToDelete);
+        //                    Module updatedModule = new Module(module.getModuleName(), updatedClassmates);
+        //                    model.setModule(module, updatedModule);
+        //                    return updatedModule;
+        //                }).collect(Collectors.toList());
+
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -18,6 +18,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -82,8 +83,24 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        // update address book
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        // update meeting book
+        List<Meeting> filteredMeetingList = model.getFilteredMeetingList().stream()
+                .filter(meeting -> meeting.getMembers().contains(personToEdit)).map(meeting -> {
+                    Set<Person> updatedMembers = new HashSet<>(meeting.getMembers());
+                    updatedMembers.remove(personToEdit);
+                    updatedMembers.add(editedPerson);
+                    Meeting updatedMeeting = new Meeting(meeting.getMeetingName(), meeting.getDate(),
+                            meeting.getTime(), updatedMembers);
+                    model.setMeeting(meeting, updatedMeeting);
+                    return updatedMeeting;
+                }).collect(Collectors.toList());
+
+        // todo update module book
+
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -126,13 +126,13 @@ public interface Model {
     void addMeeting(Meeting meeting);
 
     /**
-     * Returns true if a meeting with the same meeting name as {@code meeting} exists in the address book.
+     * Returns true if a meeting with the same meeting name as {@code meeting} exists in the meeting book.
      */
     boolean hasMeetingName(MeetingName meetingName);
 
     /**
      * Deletes the given meeting.
-     * The person must exist in the address book.
+     * The person must exist in the meeting book.
      */
     void deleteMeeting(Meeting targetMeeting);
 
@@ -140,7 +140,7 @@ public interface Model {
      * Replaces the given meeting {@code target} with {@code editedMeeting}.
      * {@code target} must exist in the meeting book.
      * The meeting identity of {@code editedMeeting} must not be the same
-     * as another existing meeting in the address book.
+     * as another existing meeting in the meeting book.
      */
     void setMeeting(Meeting target, Meeting editedMeeting);
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -298,6 +298,8 @@ public class ModelManager implements Model {
         // state check
         ModelManager other = (ModelManager) obj;
         return addressBook.equals(other.addressBook)
+                && meetingBook.equals(other.meetingBook)
+                && moduleBook.equals(other.moduleBook)
                 && userPrefs.equals(other.userPrefs)
                 && filteredPersons.equals(other.filteredPersons);
     }

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -57,6 +57,7 @@ public class Name {
     }
 
     public String getFirstName() {
-        return fullName.substring(0, fullName.indexOf(" "));
+        int spaceIndex = fullName.indexOf(" ");
+        return spaceIndex == -1 ? fullName : fullName.substring(0, spaceIndex);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalMeetings.getTypicalMeetingBook;
+import static seedu.address.testutil.TypicalMeetings.getTypicalMeetingBookWithMember;
 import static seedu.address.testutil.TypicalModules.getTypicalModuleBook;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
@@ -24,13 +25,16 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 
 /**
- * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
+ * Contains integration tests (interaction with the Model, Meetings, UndoCommand, RedoCommand,) and unit tests for
  * {@code DeleteCommand}.
  */
 public class DeleteCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), getTypicalMeetingBook(), getTypicalModuleBook(),
         new UserPrefs());
+
+    private Model modelWithMembersInMeetings = new ModelManager(getTypicalAddressBook(),
+            getTypicalMeetingBookWithMember(), getTypicalModuleBook(), new UserPrefs());
 
     @Test
     public void execute_validNameUnfilteredList_success() {
@@ -81,6 +85,21 @@ public class DeleteCommandTest {
         DeleteCommand deleteCommand = new DeleteCommand(new Name("123"));
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED);
+    }
+
+    /**
+     * Delete the contact and meeting containing the contact will be updated.
+     */
+    @Test
+    public void execute_validNameAndNameInOneMeeting_success() {
+        Person personToDelete = ALICE;
+        DeleteCommand deleteCommand = new DeleteCommand(personToDelete.getName());
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+
+        Model expectedModel = model;
+        model.deletePerson(personToDelete);
+
+        assertCommandSuccess(deleteCommand, modelWithMembersInMeetings, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -13,12 +13,15 @@ import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalMeetings.getTypicalMeetingBook;
+import static seedu.address.testutil.TypicalMeetings.getTypicalMeetingBookWithEditedMember;
+import static seedu.address.testutil.TypicalMeetings.getTypicalMeetingBookWithMember;
 import static seedu.address.testutil.TypicalModules.getTypicalModuleBook;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.GEORGE;
+import static seedu.address.testutil.TypicalPersons.getEditedTypicalAddressBook;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -38,12 +41,16 @@ import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 
 /**
- * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for EditCommand.
+ * Contains integration tests (interaction with the Model, Meeting, UndoCommand and RedoCommand) and unit tests for
+ * EditCommand.
  */
 public class EditCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), getTypicalMeetingBook(), getTypicalModuleBook(),
         new UserPrefs());
+
+    private Model modelWithMembersInMeetings = new ModelManager(getTypicalAddressBook(),
+            getTypicalMeetingBookWithMember(), getTypicalModuleBook(), new UserPrefs());
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
@@ -165,6 +172,23 @@ public class EditCommandTest {
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED);
+    }
+
+    /**
+     * Edit contact name and meeting containing the contact name will also be edited.
+     */
+    @Test
+    public void execute_validNameAndNameInOneMeeting_success() {
+        Person editedPerson = new PersonBuilder(ALICE).withName("Alicia").build();
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(ALICE).withName("Alicia").build();
+        EditCommand editCommand = new EditCommand(ALICE.getName(), descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(getEditedTypicalAddressBook(), getTypicalMeetingBookWithEditedMember(),
+                getTypicalModuleBook(), new UserPrefs());
+
+        assertCommandSuccess(editCommand, modelWithMembersInMeetings, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalMeetings.java
+++ b/src/test/java/seedu/address/testutil/TypicalMeetings.java
@@ -1,17 +1,36 @@
 package seedu.address.testutil;
 
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.ALICIA;
+
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import seedu.address.model.MeetingBook;
 import seedu.address.model.meeting.Meeting;
+import seedu.address.model.person.Person;
 
 public class TypicalMeetings {
 
+    public static final Meeting CS2103_NO_MEMBERS = new MeetingBuilder().withName("CS2103")
+            .withDate("2020-10-07")
+            .withTime("10:00")
+            .withMembers(new HashSet<Person>(Arrays.asList(ALICE)))
+            .build();
+
     public static final Meeting CS2103 = new MeetingBuilder().withName("CS2103")
             .withDate("2020-10-07")
-            .withTime("10:00").build();
+            .withTime("10:00")
+            .build();
+
+    // Edited name from Alice Pauline to Alicia
+    public static final Meeting CS2103_EDITED_MEMBER = new MeetingBuilder().withName("CS2103")
+            .withDate("2020-10-07")
+            .withTime("10:00")
+            .withMembers(new HashSet<Person>(Arrays.asList(ALICIA)))
+            .build();
 
     /*
     // Manually added
@@ -29,6 +48,7 @@ public class TypicalMeetings {
 
     private TypicalMeetings() {} // prevents instantiation
      */
+    // meeting has no members
     public static MeetingBook getTypicalMeetingBook() {
         MeetingBook mb = new MeetingBook();
         for (Meeting meeting : getTypicalMeetings()) {
@@ -37,7 +57,31 @@ public class TypicalMeetings {
         return mb;
     }
 
+    // meeting has one member
+    public static MeetingBook getTypicalMeetingBookWithMember() {
+        MeetingBook mb = new MeetingBook();
+        for (Meeting meeting : getTypicalMeetingsWithMembers()) {
+            mb.addMeeting(meeting);
+        }
+        return mb;
+    }
+
+    // meeting has edited member
+    public static MeetingBook getTypicalMeetingBookWithEditedMember() {
+        MeetingBook mb = new MeetingBook();
+        for (Meeting meeting : getTypicalMeetingsWithEditedMember()) {
+            mb.addMeeting(meeting);
+        }
+        return mb;
+    }
+
     public static List<Meeting> getTypicalMeetings() {
         return new ArrayList<>(Arrays.asList(CS2103));
+    }
+    public static List<Meeting> getTypicalMeetingsWithMembers() {
+        return new ArrayList<>(Arrays.asList(CS2103_NO_MEMBERS));
+    }
+    public static List<Meeting> getTypicalMeetingsWithEditedMember() {
+        return new ArrayList<>(Arrays.asList(CS2103_EDITED_MEMBER));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -25,6 +25,10 @@ public class TypicalPersons {
             .withEmail("alice@example.com")
             .withPhone("94351253")
             .withTags("friends").build();
+    public static final Person ALICIA = new PersonBuilder().withName("Alicia")
+            .withEmail("alice@example.com")
+            .withPhone("94351253")
+            .withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends").build();
@@ -67,7 +71,19 @@ public class TypicalPersons {
         return ab;
     }
 
+    public static AddressBook getEditedTypicalAddressBook() {
+        AddressBook ab = new AddressBook();
+        for (Person person : getEditedTypicalPersons()) {
+            ab.addPerson(person);
+        }
+        return ab;
+    }
+
     public static List<Person> getTypicalPersons() {
         return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+    }
+
+    public static List<Person> getEditedTypicalPersons() {
+        return new ArrayList<>(Arrays.asList(ALICIA, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
     }
 }


### PR DESCRIPTION
fix #129 
fix #133 
- Editing and deleting contacts will update meeting state if contact is part of a meeting
- Fix bug where one word names can't be used for meetings and modules
- Added test cases