### PR TITLE
Extend delete command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -75,14 +75,16 @@ Example:
 
 ### Deleting a contact : `contact delete`
 
-Deletes the specified contact from Modduke.
+Delete contacts with the given criteria from Modduke.
 
-Format: `contact delete CONTACT_NAME`
+Format: `contact delete [n/CONTACT_NAME] [m/MODULE_NAME] [t/TAG_NAME]`
 
-* Deletes the contact with the specified name.
+* [n/CONTACT_NAME], [m/MODULE_NAME] and [t/TAG_NAME] are all optional fields,
+* At least one of the optional fields must be provided.
 
 Examples:
-* `contact delete Roy` deletes `Roy` contact from Modduke.
+* `contact delete n/Roy n/Jake` delete contacts `Roy` and `Jake` from Modduke.
+* `contact delete m/CS2103 t/classmates` deletes all contacts in `CS2103` module or have `classmates` tag
 
 ### Editing a contact : `contact edit`
 
@@ -234,7 +236,7 @@ Format: `consult list`
 
 ### Copy email address of contacts : `copy email`
 
-Copies email address of contacts with the given criteria to your clipboard
+Copies email address of contacts with the given criteria to your clipboard.
 
 Format: `copy email [n/CONTACT_NAME] [m/MODULE_NAME] [t/TAG_NAME]`
 
@@ -247,7 +249,7 @@ Examples:
 
 ### Copy phone numbers of contacts : `copy phone`
 
-Copies phone numbers of contacts with the given criteria to your clipboard
+Copies phone numbers of contacts with the given criteria to your clipboard.
 
 Format: `copy phone [n/CONTACT_NAME] [m/MODULE_NAME] [t/TAG_NAME]`
 

--- a/src/main/java/seedu/address/logic/commands/AddLabelCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLabelCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/main/java/seedu/address/logic/commands/AddLabelCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLabelCommand.java
@@ -14,7 +14,6 @@ import java.util.stream.Collectors;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
@@ -72,21 +71,12 @@ public class AddLabelCommand extends Command {
         }
 
         model.setPerson(personToLabel, labelledPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         // update meeting book
-        List<Meeting> filteredMeetingList = model.getFilteredMeetingList().stream()
-                .filter(meeting -> meeting.getParticipants().contains(personToLabel)).map(meeting -> {
-                    Set<Person> updatedMembers = new HashSet<>(meeting.getParticipants());
-                    updatedMembers.remove(personToLabel);
-                    updatedMembers.add(labelledPerson);
-                    Meeting updatedMeeting = new Meeting(meeting.getModule(), meeting.getMeetingName(),
-                            meeting.getDate(), meeting.getTime(), updatedMembers);
-                    model.setMeeting(meeting, updatedMeeting);
-                    return updatedMeeting;
-                }).collect(Collectors.toList());
+        model.updatePersonInMeetingBook(personToLabel, labelledPerson);
 
-        // todo update module book
+        // update module book
+        model.updatePersonInModuleBook(personToLabel, labelledPerson);
 
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, labelledPerson));
     }

--- a/src/main/java/seedu/address/logic/commands/ClearLabelCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearLabelCommand.java
@@ -5,13 +5,11 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 
@@ -45,22 +43,14 @@ public class ClearLabelCommand extends Command {
                 .filter(person -> person.isSameName(targetName)).collect(Collectors.toList());
         Person personToClear = filteredList.get(0);
         Person clearedPerson = createClearedPerson(personToClear); // clears all labels from Person
+
         model.setPerson(personToClear, clearedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         // update meeting book
-        List<Meeting> filteredMeetingList = model.getFilteredMeetingList().stream()
-                .filter(meeting -> meeting.getParticipants().contains(personToClear)).map(meeting -> {
-                    Set<Person> updatedMembers = new HashSet<>(meeting.getParticipants());
-                    updatedMembers.remove(personToClear);
-                    updatedMembers.add(clearedPerson);
-                    Meeting updatedMeeting = new Meeting(meeting.getModule(), meeting.getMeetingName(),
-                            meeting.getDate(), meeting.getTime(), updatedMembers);
-                    model.setMeeting(meeting, updatedMeeting);
-                    return updatedMeeting;
-                }).collect(Collectors.toList());
+        model.updatePersonInMeetingBook(personToClear, clearedPerson);
 
-        // todo update module book
+        // update module book
+        model.updatePersonInModuleBook(personToClear, clearedPerson);
 
         return new CommandResult(String.format("All labels of person '%s' have been cleared!", targetName.toString()));
     }

--- a/src/main/java/seedu/address/logic/commands/ClearLabelCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearLabelCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.HashSet;
 import java.util.List;

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,18 +1,21 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.meeting.Meeting;
-import seedu.address.model.person.Name;
+import seedu.address.model.module.ModuleName;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonPredicate;
 
 /**
  * Deletes a person identified using it's displayed index from the address book.
@@ -23,44 +26,61 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the name used in the displayed person list.\n"
-            + "Parameters: NAME (must be a valid name)\n"
-            + "Example: " + COMMAND_WORD + " Roy";
+            + "Parameters: "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_MODULE + "MODULE] "
+            + "[" + PREFIX_TAG + "TAG]\n"
+            + "Example: " + COMMAND_WORD + " n/Roy t/friend";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted People: %1$s";
 
-    private final Name targetName;
+    private final PersonPredicate predicate;
+    private final List<ModuleName> moduleNames;
 
-    public DeleteCommand(Name targetName) {
-        this.targetName = targetName;
+    /**
+     * @param predicate the predicate based on the names, modules and tags given
+     */
+    public DeleteCommand(PersonPredicate predicate, List<ModuleName> moduleNames) {
+        this.predicate = predicate;
+        this.moduleNames = moduleNames;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        boolean isValidContact = model.hasPersonName(targetName);
-
-        if (!isValidContact) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED);
+        List<Person> people;
+        if (moduleNames.isEmpty()) {
+            // finds Persons that match the predicate only
+            people = model.getUpdatedFilteredPersonList(predicate);
+        } else {
+            // finds Persons that match the predicate and Persons that have the given Modules
+            people = model.getUpdatedFilteredPersonList(predicate, moduleNames);
         }
 
         // Update address book
-        List<Person> filteredList = model.getFilteredPersonList().stream()
-                .filter(person -> person.isSameName(targetName)).collect(Collectors.toList());
-        assert filteredList.size() == 1;
-        Person personToDelete = filteredList.get(0);
-        model.deletePerson(personToDelete);
+        people.stream().forEach(
+                p -> {
+                    List<Person> filteredList = model.getFilteredPersonList().stream()
+                            .filter(person -> person.isSameName(p.getName())).collect(Collectors.toList());
+                    assert filteredList.size() == 1;
+                    Person personToDelete = filteredList.get(0);
+                    model.deletePerson(personToDelete);
+                    List<Meeting> filteredMeetingList = model.getFilteredMeetingList().stream()
+                            .filter(meeting -> meeting.getParticipants().contains(personToDelete)).map(meeting -> {
+                                Set<Person> updatedMembers = new HashSet<>(meeting.getParticipants());
+                                updatedMembers.remove(personToDelete);
+                                Meeting updatedMeeting = new Meeting(meeting.getModule(), meeting.getMeetingName(),
+                                        meeting.getDate(), meeting.getTime(), updatedMembers);
+                                model.setMeeting(meeting, updatedMeeting);
+                                return updatedMeeting;
+                            }).collect(Collectors.toList());
+                    model.updatePersonInMeetingBook(personToDelete);
+                }
+        );
 
-        // Update meeting book
-        List<Meeting> filteredMeetingList = model.getFilteredMeetingList().stream()
-                .filter(meeting -> meeting.getParticipants().contains(personToDelete)).map(meeting -> {
-                    Set<Person> updatedMembers = new HashSet<>(meeting.getParticipants());
-                    updatedMembers.remove(personToDelete);
-                    Meeting updatedMeeting = new Meeting(meeting.getModule(), meeting.getMeetingName(),
-                            meeting.getDate(), meeting.getTime(), updatedMembers);
-                    model.setMeeting(meeting, updatedMeeting);
-                    return updatedMeeting;
-                }).collect(Collectors.toList());
-        model.updatePersonInMeetingBook(personToDelete);
+        String deletedNames = people.stream()
+                .map(p -> p.getName().toString())
+                .reduce("", (x, y) -> x + y + " ");
 
         // todo update module book
         //        List<Meeting> filteredModuleList = model.getFilteredModuleList().stream()
@@ -72,13 +92,14 @@ public class DeleteCommand extends Command {
         //                    return updatedModule;
         //                }).collect(Collectors.toList());
 
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, deletedNames));
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DeleteCommand // instanceof handles nulls
-                && targetName.equals(((DeleteCommand) other).targetName)); // state check
+                && predicate.equals(((DeleteCommand) other).predicate)
+                && moduleNames.equals(((DeleteCommand) other).moduleNames)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -6,14 +6,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.meeting.Meeting;
 import seedu.address.model.module.ModuleName;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonPredicate;

--- a/src/main/java/seedu/address/logic/commands/DeleteLabelCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLabelCommand.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;

--- a/src/main/java/seedu/address/logic/commands/DeleteLabelCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLabelCommand.java
@@ -58,19 +58,11 @@ public class DeleteLabelCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
 
-        // Update meeting book
-        List<Meeting> filteredMeetingList = model.getFilteredMeetingList().stream()
-                .filter(meeting -> meeting.getParticipants().contains(personToEdit)).map(meeting -> {
-                    Set<Person> updatedMembers = new HashSet<>(meeting.getParticipants());
-                    updatedMembers.remove(personToEdit);
-                    updatedMembers.add(editedPerson);
-                    Meeting updatedMeeting = new Meeting(meeting.getModule(), meeting.getMeetingName(),
-                            meeting.getDate(), meeting.getTime(), updatedMembers);
-                    model.setMeeting(meeting, updatedMeeting);
-                    return updatedMeeting;
-                }).collect(Collectors.toList());
+        // update meeting book
+        model.updatePersonInMeetingBook(personToEdit, editedPerson);
 
-        // todo update module book
+        // update module book
+        model.updatePersonInModuleBook(personToEdit, editedPerson);
 
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, editedPerson));
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -89,18 +89,10 @@ public class EditCommand extends Command {
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         // update meeting book
-        List<Meeting> filteredMeetingList = model.getFilteredMeetingList().stream()
-                .filter(meeting -> meeting.getParticipants().contains(personToEdit)).map(meeting -> {
-                    Set<Person> updatedMembers = new HashSet<>(meeting.getParticipants());
-                    updatedMembers.remove(personToEdit);
-                    updatedMembers.add(editedPerson);
-                    Meeting updatedMeeting = new Meeting(meeting.getModule(), meeting.getMeetingName(),
-                            meeting.getDate(), meeting.getTime(), updatedMembers);
-                    model.setMeeting(meeting, updatedMeeting);
-                    return updatedMeeting;
-                }).collect(Collectors.toList());
         model.updatePersonInMeetingBook(personToEdit, editedPerson);
-        // todo update module book
+
+        // update module book
+        model.updatePersonInModuleBook(personToEdit, editedPerson);
 
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -18,7 +18,6 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;

--- a/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -16,7 +15,6 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.CopyCommand;
-import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.ModuleName;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -141,10 +139,10 @@ public class CopyCommandParser implements Parser<CopyCommand> {
     private Optional<Set<Tag>> parseTagsForFind(Collection<String> tags) throws ParseException {
         assert tags != null;
 
-        if (tags.isEmpty()) {
+        if (tags.isEmpty() || (tags.size() == 1 && tags.contains(""))) {
             return Optional.empty();
         }
-        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        Collection<String> tagSet = tags;
         return Optional.of(ParserUtil.parseTags(tagSet));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
@@ -65,7 +65,7 @@ public class CopyCommandParser implements Parser<CopyCommand> {
             Set<Tag> tagSet = parseTagsForFind(argMultimap.getAllValues(PREFIX_TAG)).orElse(new HashSet<>());
             // check if any of the collections are empty (no text after prefixes)
             if ((nameSet.size() == 1 && nameSet.contains("")) || tagSet.isEmpty()) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CopyCommand.MESSAGE_USAGE));
             }
             return new CopyCommand(
                     new PersonHasTagsAndNamePredicate(new ArrayList<>(nameSet), new ArrayList<>(tagSet)),

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -6,6 +6,14 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.ModuleName;
@@ -13,15 +21,6 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.PersonHasTagsAndNamePredicate;
 import seedu.address.model.person.PersonHasTagsPredicate;
 import seedu.address.model.tag.Tag;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -133,10 +132,10 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     private Optional<Set<Tag>> parseTagsForFind(Collection<String> tags) throws ParseException {
         assert tags != null;
 
-        if (tags.isEmpty()) {
+        if (tags.isEmpty() || (tags.size() == 1 && tags.contains(""))) {
             return Optional.empty();
         }
-        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        Collection<String> tagSet = tags;
         return Optional.of(ParserUtil.parseTags(tagSet));
     }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,10 +1,27 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Name;
+import seedu.address.model.module.ModuleName;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PersonHasTagsAndNamePredicate;
+import seedu.address.model.person.PersonHasTagsPredicate;
+import seedu.address.model.tag.Tag;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -17,13 +34,110 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
-        try {
-            Name targetName = ParserUtil.parseName(args);
-            return new DeleteCommand(targetName);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG, PREFIX_MODULE);
+
+        if (arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_TAG, PREFIX_MODULE)) {
+            Set<String> nameSet = ParserUtil.parseAllNames(argMultimap.getAllValues(PREFIX_NAME));
+            Set<Tag> tagSet = parseTagsForFind(argMultimap.getAllValues(PREFIX_TAG)).orElse(new HashSet<>());
+            List<String> moduleNames = argMultimap.getAllValues(PREFIX_MODULE);
+            // check if any of the collections are empty (no text after prefixes)
+            if ((nameSet.size() == 1 && nameSet.contains(""))
+                    || tagSet.isEmpty()
+                    || (moduleNames.size() == 1 && moduleNames.contains(""))) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            }
+            Set<ModuleName> moduleNameSet = ParserUtil.parseAllModules(moduleNames);
+            return new DeleteCommand(
+                    new PersonHasTagsAndNamePredicate(new ArrayList<>(nameSet), new ArrayList<>(tagSet)),
+                    new ArrayList<>(moduleNameSet));
+        } else if (arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_TAG)) {
+            Set<String> nameSet = ParserUtil.parseAllNames(argMultimap.getAllValues(PREFIX_NAME));
+            Set<Tag> tagSet = parseTagsForFind(argMultimap.getAllValues(PREFIX_TAG)).orElse(new HashSet<>());
+            // check if any of the collections are empty (no text after prefixes)
+            if ((nameSet.size() == 1 && nameSet.contains("")) || tagSet.isEmpty()) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            }
+            return new DeleteCommand(
+                    new PersonHasTagsAndNamePredicate(new ArrayList<>(nameSet), new ArrayList<>(tagSet)),
+                    new ArrayList<ModuleName>());
+        } else if (arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_MODULE)) {
+            Set<String> nameSet = ParserUtil.parseAllNames(argMultimap.getAllValues(PREFIX_NAME));
+            List<String> moduleNames = argMultimap.getAllValues(PREFIX_MODULE);
+            // check if any of the collections are empty (no text after prefixes)
+            if ((nameSet.size() == 1 && nameSet.contains(""))
+                    || (moduleNames.size() == 1 && moduleNames.contains(""))) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            }
+            Set<ModuleName> moduleNameSet = ParserUtil.parseAllModules(moduleNames);
+            return new DeleteCommand(
+                    new NameContainsKeywordsPredicate(new ArrayList<>(nameSet)),
+                    new ArrayList<>(moduleNameSet));
+        } else if (arePrefixesPresent(argMultimap, PREFIX_MODULE, PREFIX_TAG)) {
+            Set<Tag> tagSet = parseTagsForFind(argMultimap.getAllValues(PREFIX_TAG)).orElse(new HashSet<>());
+            List<String> moduleNames = argMultimap.getAllValues(PREFIX_MODULE);
+            // check if any of the collections are empty (no text after prefixes)
+            if (tagSet.isEmpty() || (moduleNames.size() == 1 && moduleNames.contains(""))) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            }
+            Set<ModuleName> moduleNameSet = ParserUtil.parseAllModules(moduleNames);
+            return new DeleteCommand(
+                    new PersonHasTagsPredicate(new ArrayList<>(tagSet)),
+                    new ArrayList<>(moduleNameSet));
+        } else if (arePrefixesPresent(argMultimap, PREFIX_NAME)) {
+            Set<String> nameSet = ParserUtil.parseAllNames(argMultimap.getAllValues(PREFIX_NAME));
+            // check if any of the collections are empty (no text after prefixes)
+            if (nameSet.size() == 1 && nameSet.contains("")) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            }
+            return new DeleteCommand(
+                    new NameContainsKeywordsPredicate(new ArrayList<>(nameSet)),
+                    new ArrayList<ModuleName>());
+        } else if (arePrefixesPresent(argMultimap, PREFIX_TAG)) {
+            Set<Tag> tagSet = parseTagsForFind(argMultimap.getAllValues(PREFIX_TAG))
+                    .orElseThrow(() -> new ParseException(
+                            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE)));
+            return new DeleteCommand(
+                    new PersonHasTagsPredicate(new ArrayList<>(tagSet)),
+                    new ArrayList<ModuleName>());
+        } else if (arePrefixesPresent(argMultimap, PREFIX_MODULE)) {
+            List<String> moduleNames = argMultimap.getAllValues(PREFIX_MODULE);
+            // check if any of the collections are empty (no text after prefixes)
+            if (moduleNames.size() == 1 && moduleNames.contains("")) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            }
+            Set<ModuleName> moduleNameSet = ParserUtil.parseAllModules(moduleNames);
+            return new DeleteCommand(
+                    new PersonHasTagsPredicate(new ArrayList<>()),
+                    new ArrayList<>(moduleNameSet));
+        } else {
+            // no valid prefixes provided
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
+     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero tags.
+     */
+    private Optional<Set<Tag>> parseTagsForFind(Collection<String> tags) throws ParseException {
+        assert tags != null;
+
+        if (tags.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        return Optional.of(ParserUtil.parseTags(tagSet));
     }
 
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -195,4 +195,11 @@ public interface Model {
     ObservableList<Module> getFilteredModuleList();
 
     void getPersonsInModule(ModuleName moduleName) throws CommandException;
+
+    /**
+     * Updates all modules in the module book if the required person was part of any module.
+     * @param persons First argument is the person to update which is either deleted or replaced. If replaced,
+     * second argument is the edited person who will replace the deleted person.
+     */
+    void updatePersonInModuleBook(Person ...persons);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -254,6 +254,29 @@ public class ModelManager implements Model {
         this.moduleBook.resetData(newBook);
     }
 
+    @Override
+    public void updatePersonInModuleBook(Person ...persons) {
+        requireNonNull(persons);
+        Person personToUpdate = persons[0];
+        boolean isReplacement = persons.length > 1;
+
+        filteredModules.stream()
+                .filter(module -> module.getClassmates().contains(personToUpdate))
+                .forEach(module -> {
+                    Set<Person> updatedClassmates = new HashSet<>(module.getClassmates());
+                    logger.fine("Removing contact from relevant module.");
+                    updatedClassmates.remove(personToUpdate);
+                    if (isReplacement) {
+                        assert persons.length == 2;
+                        Person editedPerson = persons[1];
+                        logger.fine("Adding edited contact to relevant module.");
+                        updatedClassmates.add(editedPerson);
+                    }
+                    Module updatedModule = new Module(module.getModuleName(), updatedClassmates);
+                    moduleBook.setModule(module, updatedModule);
+                });
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -272,6 +272,11 @@ public class AddCommandTest {
         public void getPersonsInModule(ModuleName moduleName) throws CommandException {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void updatePersonInModuleBook(Person ...persons) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddLabelCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddLabelCommandTest.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.commands.CommandTestUtil.LABEL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.LABEL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalMeetings.getTypicalMeetingBook;

--- a/src/test/java/seedu/address/logic/commands/AddLabelCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddLabelCommandTest.java
@@ -43,8 +43,6 @@ public class AddLabelCommandTest {
 
     @Test
     public void execute_filteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person labelledPerson = new PersonBuilder(personInFilteredList).withTags("professor").build();
         AddLabelCommand labelCommand = new AddLabelCommand(labelledPerson.getName(),
@@ -61,6 +59,9 @@ public class AddLabelCommandTest {
                                                 new ModuleBook(model.getModuleBook()),
                                                 new UserPrefs());
         expectedModel.setPerson(personInFilteredList, finalPerson);
+        expectedModel.updatePersonInMeetingBook(personInFilteredList, finalPerson);
+        expectedModel.updatePersonInModuleBook(personInFilteredList, finalPerson);
+        expectedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
         assertCommandSuccess(labelCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/AddMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMeetingCommandTest.java
@@ -276,6 +276,11 @@ public class AddMeetingCommandTest {
         public void getPersonsInModule(ModuleName moduleName) throws CommandException {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void updatePersonInModuleBook(Person ...persons) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -2,11 +2,8 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalMeetings.getTypicalMeetingBook;
 import static seedu.address.testutil.TypicalMeetings.getTypicalMeetingBookWithMember;
 import static seedu.address.testutil.TypicalModules.getTypicalModuleBook;
@@ -14,14 +11,14 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.util.ArrayList;
+
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.core.Messages;
-import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.Name;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 
 /**
@@ -39,9 +36,14 @@ public class DeleteCommandTest {
     @Test
     public void execute_validNameUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(personToDelete.getName());
+        ArrayList<String> nameOne = new ArrayList<>();
+        nameOne.add(personToDelete.getName().getFirstName());
+        DeleteCommand deleteCommand = new DeleteCommand(
+                new NameContainsKeywordsPredicate(nameOne), new ArrayList<>()
+        );
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                personToDelete.getName().toString());
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), model.getMeetingBook(),
             model.getModuleBook(), new UserPrefs());
@@ -50,51 +52,19 @@ public class DeleteCommandTest {
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 
-    @Test
-    public void execute_invalidNameUnfilteredList_throwsCommandException() {
-        DeleteCommand deleteCommand = new DeleteCommand(new Name("123"));
-
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED);
-    }
-
-    @Test
-    public void execute_validNameFilteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(personToDelete.getName());
-
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
-
-        Model expectedModel = new ModelManager(model.getAddressBook(), model.getMeetingBook(),
-            model.getModuleBook(), new UserPrefs());
-        expectedModel.deletePerson(personToDelete);
-        showNoPerson(expectedModel);
-
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_invalidNameFilteredList_throwsCommandException() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
-
-        DeleteCommand deleteCommand = new DeleteCommand(new Name("123"));
-
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED);
-    }
-
     /**
      * Delete the contact and meeting containing the contact will be updated.
      */
     @Test
     public void execute_validNameAndNameInOneMeeting_success() {
         Person personToDelete = ALICE;
-        DeleteCommand deleteCommand = new DeleteCommand(personToDelete.getName());
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+        ArrayList<String> nameOne = new ArrayList<>();
+        nameOne.add(personToDelete.getName().getFirstName());
+        DeleteCommand deleteCommand = new DeleteCommand(
+                new NameContainsKeywordsPredicate(nameOne), new ArrayList<>()
+        );
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                personToDelete.getName().toString());
 
         Model expectedModel = model;
         model.deletePerson(personToDelete);
@@ -104,14 +74,21 @@ public class DeleteCommandTest {
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(ALICE.getName());
-        DeleteCommand deleteSecondCommand = new DeleteCommand(BOB.getName());
+        ArrayList<String> nameOne = new ArrayList<>();
+        nameOne.add(ALICE.getName().getFirstName());
+        ArrayList<String> nameTwo = new ArrayList<>();
+        nameTwo.add(BOB.getName().getFirstName());
+        DeleteCommand deleteFirstCommand = new DeleteCommand(
+                new NameContainsKeywordsPredicate(nameOne), new ArrayList<>());
+        DeleteCommand deleteSecondCommand = new DeleteCommand(
+                new NameContainsKeywordsPredicate(nameTwo), new ArrayList<>());
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(ALICE.getName());
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(
+                new NameContainsKeywordsPredicate(nameOne), new ArrayList<>());
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -7,6 +7,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 //import java.util.Arrays;
@@ -26,6 +27,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -54,8 +56,10 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + TypicalPersons.ALICE.getName().toString());
-        assertEquals(new DeleteCommand(TypicalPersons.ALICE.getName()), command);
+                DeleteCommand.COMMAND_WORD + " n/" + TypicalPersons.ALICE.getName().toString());
+        ArrayList<String> nameOne = new ArrayList<>();
+        nameOne.add(TypicalPersons.ALICE.getName().toString());
+        assertEquals(new DeleteCommand(new NameContainsKeywordsPredicate(nameOne), new ArrayList<>()), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/CopyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CopyCommandParserTest.java
@@ -43,7 +43,6 @@ public class CopyCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsCopyCommand() {
-        // no leading and trailing whitespaces
         ArrayList<String> nameList = new ArrayList<>();
         nameList.add("Alice");
         ArrayList<Tag> tagList = new ArrayList<>();
@@ -104,5 +103,40 @@ public class CopyCommandParserTest {
                         moduleNames);
 
         assertParseSuccess(parser, " email \n m/CS2103 \n n/Alice \n t/tag\t", expectedCopyCommand);
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // no input
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CopyCommand.MESSAGE_USAGE));
+
+        // empty name prefix
+        assertParseFailure(parser, "n/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CopyCommand.MESSAGE_USAGE));
+
+        // empty tag prefix
+        assertParseFailure(parser, "t/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CopyCommand.MESSAGE_USAGE));
+
+        // empty module prefix
+        assertParseFailure(parser, "m/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CopyCommand.MESSAGE_USAGE));
+
+        // empty name prefix with other prefixes
+        assertParseFailure(parser, " n/ t/tag",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CopyCommand.MESSAGE_USAGE));
+
+        // empty tag prefix with other prefixes
+        assertParseFailure(parser, " m/CS2103 t/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CopyCommand.MESSAGE_USAGE));
+
+        // empty module prefix with other prefixes
+        assertParseFailure(parser, " m/ t/tag",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CopyCommand.MESSAGE_USAGE));
+
+        // multiple empty prefixes
+        assertParseFailure(parser, " n/ t/ m/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CopyCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -3,11 +3,17 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalPersons.ALICE;
+
+import java.util.ArrayList;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.model.module.ModuleName;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PersonHasTagsAndNamePredicate;
+import seedu.address.model.person.PersonHasTagsPredicate;
+import seedu.address.model.tag.Tag;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -22,11 +28,100 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "Alice Pauline", new DeleteCommand(ALICE.getName()));
+        ArrayList<String> nameList = new ArrayList<>();
+        nameList.add("Alice");
+        ArrayList<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("tag"));
+        ArrayList<ModuleName> moduleNames = new ArrayList<>();
+        moduleNames.add(new ModuleName("CS2103"));
+
+        // only name prefix, email
+        DeleteCommand expectedDeleteCommand =
+                new DeleteCommand(new NameContainsKeywordsPredicate(nameList),
+                        new ArrayList<ModuleName>());
+        assertParseSuccess(parser, "email n/Alice", expectedDeleteCommand);
+
+        // only tag prefix, email
+        expectedDeleteCommand =
+                new DeleteCommand(new PersonHasTagsPredicate(tagList),
+                        new ArrayList<ModuleName>());
+
+        assertParseSuccess(parser, "email t/tag", expectedDeleteCommand);
+
+        // only module prefix, phone
+        expectedDeleteCommand =
+                new DeleteCommand(new PersonHasTagsPredicate(new ArrayList<>()),
+                        moduleNames);
+
+        assertParseSuccess(parser, "phone m/CS2103", expectedDeleteCommand);
+
+        // name and tag prefix, phone
+        expectedDeleteCommand =
+                new DeleteCommand(new PersonHasTagsAndNamePredicate(nameList, tagList),
+                        new ArrayList<ModuleName>());
+
+        assertParseSuccess(parser, "phone n/Alice t/tag", expectedDeleteCommand);
+
+        // name and module prefix, email
+        expectedDeleteCommand =
+                new DeleteCommand(new NameContainsKeywordsPredicate(nameList),
+                        moduleNames);
+
+        assertParseSuccess(parser, "email n/Alice m/CS2103", expectedDeleteCommand);
+
+        // tag and module prefix, email
+        expectedDeleteCommand = new DeleteCommand(new PersonHasTagsPredicate(tagList),
+                moduleNames);
+
+        assertParseSuccess(parser, "email m/CS2103 t/tag", expectedDeleteCommand);
+
+        // all prefix, phone
+        expectedDeleteCommand =
+                new DeleteCommand(new PersonHasTagsAndNamePredicate(nameList, tagList),
+                        moduleNames);
+
+        assertParseSuccess(parser, "phone n/Alice t/tag m/CS2103", expectedDeleteCommand);
+
+        // multiple whitespaces between keywords
+        expectedDeleteCommand =
+                new DeleteCommand(new PersonHasTagsAndNamePredicate(nameList, tagList),
+                        moduleNames);
+
+        assertParseSuccess(parser, " email \n m/CS2103 \n n/Alice \n t/tag\t", expectedDeleteCommand);
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        // no input
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+
+        // empty name prefix
+        assertParseFailure(parser, "n/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+
+        // empty tag prefix
+        assertParseFailure(parser, "t/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+
+        // empty module prefix
+        assertParseFailure(parser, "m/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+
+        // empty name prefix with other prefixes
+        assertParseFailure(parser, " n/ t/tag",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+
+        // empty tag prefix with other prefixes
+        assertParseFailure(parser, " m/CS2103 t/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+
+        // empty module prefix with other prefixes
+        assertParseFailure(parser, " m/ t/tag",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+
+        // multiple empty prefixes
+        assertParseFailure(parser, " n/ t/ m/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
fix #125 

Extend delete command to accept names, tags and module names as arguments.

Contacts who have the given names, tags, or are in the given modules will be deleted.